### PR TITLE
SQL-710: Use BsonTypeInfo and remove standalone type infos values (#81)

### DIFF
--- a/resources/integration_test/tests/dbmd_variable_result_sets_function_methods.yml
+++ b/resources/integration_test/tests/dbmd_variable_result_sets_function_methods.yml
@@ -5,7 +5,7 @@ tests:
     meta_function: [ getFunctions, integration_test, null, '%' ]
     expected_sql_type: [ LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, INTEGER,
                          LONGVARCHAR ]
-    expected_bson_type: [string, string, string, string, int, string]
+    expected_bson_type: [ string, string, string, string, int, string ]
     expected_catalog_name: [ '', '', '', '', '', '' ]
     expected_column_class_name: [ java.lang.String, java.lang.String, java.lang.String,
                                   java.lang.String, int, java.lang.String ]
@@ -28,84 +28,72 @@ tests:
   # getFunctions(catalog, schemaPattern, functionNamePattern)
   - description: getFunctions_no_filter_returns_all_functions
     db: integration_test
-    meta_function: [getFunctions, integration_test, null, '%']
+    meta_function: [ getFunctions, integration_test, null, '%' ]
     expected_result:
-      - [def, null, BIT_LENGTH, returns length of string in bits, 1, BIT_LENGTH]
-      - [def, null, CAST, converts the provided expression into a value of the specified
-          type., 1, CAST]
-      - [def, null, CHAR_LENGTH, returns length of string, 1, CHAR_LENGTH]
-      - [def, null, COALESCE, 'returns the first non-null value in the list, or null
-          if there are no non-null values.', 1, COALESCE]
-      - [def, null, CURRENT_TIMESTAMP, returns the current date and time., 1, CURRENT_TIMESTAMP]
-      - [def, null, CURRENT_TIMESTAMP, returns the current date and time., 1, CURRENT_TIMESTAMP]
-      - [def, null, EXTRACT, returns the value of the specified unit from the provided
-          date., 1, EXTRACT]
-      - [def, null, LOWER, returns the provided string with all characters changed
-          to lowercase., 1, LOWER]
-      - [def, null, NULLIF, 'returns null if the two arguments are equal, and the
-          first argument otherwise.', 1, NULLIF]
-      - [def, null, OCTET_LENGTH, returns length of string in bytes, 1, OCTET_LENGTH]
-      - [def, null, POSITION, returns the position of the first occurrence of substring
-          substr in string str., 1, POSITION]
-      - [def, null, SLICE, returns a slice of an array., 1, SLICE]
-      - [def, null, SIZE, returns the size of an array., 1, SIZE]
-      - [def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING]
-      - [def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING]
-      - [def, null, TRIM, returns the string str with all remstr prefixes and/or suffixes
-          removed., 1, TRIM]
-      - [def, null, TRIM, returns the string str with all remstr prefixes and/or suffixes
-          removed., 1, TRIM]
-      - [def, null, TRIM, returns the string str with all remstr prefixes and/or suffixes
-          removed., 1, TRIM]
-      - [def, null, UPPER, returns the provided string with all characters changed
-          to uppercase., 1, UPPER]
-    row_count: 19
+      - [ def, null, BIT_LENGTH, returns length of string in bits, 1, BIT_LENGTH ]
+      - [ def, null, CHAR_LENGTH, returns length of string, 1, CHAR_LENGTH ]
+      - [ def, null, CURRENT_TIMESTAMP, returns the current date and time., 1, CURRENT_TIMESTAMP ]
+      - [ def, null, CURRENT_TIMESTAMP, returns the current date and time., 1, CURRENT_TIMESTAMP ]
+      - [ def, null, EXTRACT, returns the value of the specified unit from the provided
+                                date., 1, EXTRACT ]
+      - [ def, null, LOWER, returns the provided string with all characters changed
+                              to lowercase., 1, LOWER ]
+      - [ def, null, OCTET_LENGTH, returns length of string in bytes, 1, OCTET_LENGTH ]
+      - [ def, null, POSITION, returns the position of the first occurrence of substring
+                                 substr in string str., 1, POSITION ]
+      - [ def, null, SIZE, returns the size of an array., 1, SIZE ]
+      - [ def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING ]
+      - [ def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING ]
+      - [ def, null, TRIM, returns the string str with all remstr prefixes and/or suffixes
+                             removed., 1, TRIM ]
+      - [ def, null, TRIM, returns the string str with all remstr prefixes and/or suffixes
+                             removed., 1, TRIM ]
+      - [ def, null, TRIM, returns the string str with all remstr prefixes and/or suffixes
+                             removed., 1, TRIM ]
+      - [ def, null, UPPER, returns the provided string with all characters changed
+                              to uppercase., 1, UPPER ]
+    row_count: 15
 
   - description: getFunctions_partial_filter_with_wildcard_substrings_returns_matching_functions
     db: integration_test
-    meta_function: [getFunctions, integration_test, null, '%S%']
+    meta_function: [ getFunctions, integration_test, null, '%S%' ]
     expected_result:
-      - [def, null, CAST, converts the provided expression into a value of the specified
-          type., 1, CAST]
-      - [def, null, COALESCE, 'returns the first non-null value in the list, or null
-          if there are no non-null values.', 1, COALESCE]
-      - [def, null, CURRENT_TIMESTAMP, returns the current date and time., 1, CURRENT_TIMESTAMP]
-      - [def, null, CURRENT_TIMESTAMP, returns the current date and time., 1, CURRENT_TIMESTAMP]
-      - [def, null, POSITION, returns the position of the first occurrence of substring
-          substr in string str., 1, POSITION]
-      - [def, null, SLICE, returns a slice of an array., 1, SLICE]
-      - [def, null, SIZE, returns the size of an array., 1, SIZE]
-      - [def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING]
-      - [def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING]
-    row_count: 9
+      - [ def, null, CURRENT_TIMESTAMP, returns the current date and time., 1, CURRENT_TIMESTAMP ]
+      - [ def, null, CURRENT_TIMESTAMP, returns the current date and time., 1, CURRENT_TIMESTAMP ]
+      - [ def, null, POSITION, returns the position of the first occurrence of substring
+                                 substr in string str., 1, POSITION ]
+      - [ def, null, SIZE, returns the size of an array., 1, SIZE ]
+      - [ def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING ]
+      - [ def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING ]
+    row_count: 6
 
   - description: getFunctions_partial_filter_with_wildcard_characters_returns_matching_functions
     db: integration_test
-    meta_function: [getFunctions, integration_test, null, SUBS_RIN_]
+    meta_function: [ getFunctions, integration_test, null, SUBS_RIN_ ]
     expected_result:
-      - [def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING]
-      - [def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING]
+      - [ def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING ]
+      - [ def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING ]
     row_count: 2
 
   - description: getFunctions_exact_filter_returns_matching_functions
     db: integration_test
-    meta_function: [getFunctions, integration_test, null, SUBSTRING]
+    meta_function: [ getFunctions, integration_test, null, SUBSTRING ]
     expected_result:
-      - [def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING]
-      - [def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING]
+      - [ def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING ]
+      - [ def, null, SUBSTRING, takes a substring from a string, 1, SUBSTRING ]
     row_count: 2
 
   # getFunctionColumns(catalog, schemaPattern, functionNamePattern, columnNamePattern)
   - description: getFunctionColumns_resultset_metadata_validation
     db: integration_test
-    meta_function: ["getFunctionColumns", "integration_test", null, "%", "%"]
+    meta_function: [ "getFunctionColumns", "integration_test", null, "%", "%" ]
     expected_sql_type: [ LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, INTEGER,
                          INTEGER, LONGVARCHAR, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, LONGVARCHAR,
                          INTEGER, INTEGER, LONGVARCHAR, LONGVARCHAR ]
     expected_bson_type: [ string, string, string, string, int, int, string, int, int,
                           int, int, int, string, int, int, string, string ]
     expected_catalog_name: [ '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-                           '', '', '' ]
+                             '', '', '' ]
     expected_column_class_name: [ java.lang.String, java.lang.String, java.lang.String,
                                   java.lang.String, int, int, java.lang.String, int, int, int, int, int, java.lang.String,
                                   int, int, java.lang.String, java.lang.String ]
@@ -128,7 +116,7 @@ tests:
     expected_is_definitely_writable: [ false, false, false, false, false, false, false,
                                        false, false, false, false, false, false, false, false, false, false ]
     expected_is_nullable: [ columnNullable, columnNullable, columnNoNulls, columnNoNulls,
-                            columnNoNulls, columnNoNulls, columnNoNulls, columnNoNulls, columnNoNulls, columnNullable,
+                            columnNoNulls, columnNoNulls, columnNoNulls, columnNullable, columnNoNulls, columnNullable,
                             columnNoNulls, columnNoNulls, columnNoNulls, columnNullable, columnNoNulls, columnNoNulls,
                             columnNoNulls ]
     expected_is_read_only: [ true, true, true, true, true, true, true, true, true,
@@ -143,173 +131,123 @@ tests:
   # getFunctionColumns(catalog, schemaPattern, functionNamePattern, columnNamePattern)
   - description: getFunctionColumns no function or column filters returns all args
     db: integration_test
-    meta_function: ["getFunctionColumns", "integration_test", null, "%", "%"]
+    meta_function: [ "getFunctionColumns", "integration_test", null, "%", "%" ]
     expected_result:
-      - [ def, null, BIT_LENGTH, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns length
-                                                                       of string in bits, 0, 1, 'YES', BIT_LENGTH ]
-      - [ def, null, BIT_LENGTH, argReturn, 4, 4, long, 19, 8, 0, 8, 1, returns length
-                                                                          of string in bits, 8, 1, 'YES', BIT_LENGTH ]
-      - [ def, null, CAST, arg1, 1, 0, null, 0, 0, 0, 0, 1, converts the provided expression
-                                                              into a value of the specified type., 0, 1, 'YES', CAST ]
-      - [ def, null, CAST, arg2, 1, 0, null, 0, 0, 0, 0, 1, converts the provided expression
-                                                              into a value of the specified type., 0, 2, 'YES', CAST ]
-      - [ def, null, CAST, arg3, 1, 0, null, 0, 0, 0, 0, 1, converts the provided expression
-                                                              into a value of the specified type., 0, 3, 'YES', CAST ]
-      - [ def, null, CAST, arg4, 1, 0, null, 0, 0, 0, 0, 1, converts the provided expression
-                                                              into a value of the specified type., 0, 4, 'YES', CAST ]
-      - [ def, null, CAST, argReturn, 4, 0, null, 0, 0, 0, 0, 1, converts the provided
-                                                                   expression into a value of the specified type., 0, 4, 'YES', CAST ]
-      - [ def, null, CHAR_LENGTH, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns length
-                                                                        of string, 0, 1, 'YES', CHAR_LENGTH ]
-      - [ def, null, CHAR_LENGTH, argReturn, 4, 4, long, 19, 8, 0, 8, 1, returns length
-                                                                           of string, 8, 1, 'YES', CHAR_LENGTH ]
-      - [ def, null, COALESCE, arg1, 1, 0, null, 0, 0, 0, 0, 1, 'returns the first
-          non-null value in the list, or null if there are no non-null values.', 0,
-          1, 'YES', COALESCE ]
-      - [ def, null, COALESCE, argReturn, 4, 0, null, 0, 0, 0, 0, 1, 'returns the first
-          non-null value in the list, or null if there are no non-null values.', 0,
-          1, 'YES', COALESCE ]
-      - [ def, null, CURRENT_TIMESTAMP, arg1, 1, 0, '', 0, 0, 0, 0, 1, returns the
-                                                                         current date and time., 0, 1, 'YES', CURRENT_TIMESTAMP ]
-      - [ def, null, CURRENT_TIMESTAMP, argReturn, 4, 93, date, 0, 8, 0, 8, 1, returns
-                                                                                 the current date and time., 8, 1, 'YES', CURRENT_TIMESTAMP ]
-      - [ def, null, CURRENT_TIMESTAMP, arg1, 1, 4, int, 10, 4, 0, 4, 1, returns the
-                                                                           current date and time., 4, 1, 'YES', CURRENT_TIMESTAMP ]
-      - [ def, null, CURRENT_TIMESTAMP, argReturn, 4, 93, date, 0, 8, 0, 8, 1, returns
-                                                                                 the current date and time., 8, 1, 'YES', CURRENT_TIMESTAMP ]
-      - [ def, null, EXTRACT, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns the value
-                                                                    of the specified unit from the provided date., 0, 1, 'YES', EXTRACT ]
-      - [ def, null, EXTRACT, arg2, 1, 93, date, 0, 8, 0, 8, 1, returns the value of
-                                                                  the specified unit from the provided date., 8, 2, 'YES', EXTRACT ]
-      - [ def, null, EXTRACT, argReturn, 4, 4, long, 19, 8, 0, 8, 1, returns the value
-                                                                       of the specified unit from the provided date., 8, 2, 'YES', EXTRACT ]
-      - [ def, null, LOWER, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns the provided
-                                                                  string with all characters changed to lowercase., 0, 1, 'YES', LOWER ]
-      - [ def, null, LOWER, argReturn, 4, -1, string, 0, 0, 0, 0, 1, returns the provided
-                                                                       string with all characters changed to lowercase., 0, 1, 'YES', LOWER ]
-      - [ def, null, NULLIF, arg1, 1, 0, null, 0, 0, 0, 0, 1, 'returns null if the
-          two arguments are equal, and the first argument otherwise.', 0, 1, 'YES',
-          NULLIF ]
-      - [ def, null, NULLIF, arg2, 1, 0, null, 0, 0, 0, 0, 1, 'returns null if the
-          two arguments are equal, and the first argument otherwise.', 0, 2, 'YES',
-          NULLIF ]
-      - [ def, null, NULLIF, argReturn, 4, 0, null, 0, 0, 0, 0, 1, 'returns null if
-          the two arguments are equal, and the first argument otherwise.', 0, 2, 'YES',
-          NULLIF ]
-      - [ def, null, OCTET_LENGTH, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns length
-                                                                         of string in bytes, 0, 1, 'YES', OCTET_LENGTH ]
-      - [ def, null, OCTET_LENGTH, argReturn, 4, 4, long, 19, 8, 0, 8, 1, returns length
-                                                                            of string in bytes, 8, 1, 'YES', OCTET_LENGTH ]
-      - [ def, null, POSITION, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns the position
-                                                                     of the first occurrence of substring substr in string str., 0, 1, 'YES',
-          POSITION ]
-      - [ def, null, POSITION, arg2, 1, -1, string, 0, 0, 0, 0, 1, returns the position
-                                                                     of the first occurrence of substring substr in string str., 0, 2, 'YES',
-          POSITION ]
-      - [ def, null, POSITION, argReturn, 4, 4, long, 19, 8, 0, 8, 1, returns the position
-                                                                        of the first occurrence of substring substr in string str., 8, 2, 'YES',
-          POSITION ]
-      - [ def, null, SLICE, arg1, 1, 0, array, 0, 0, 0, 0, 1, returns a slice of an
-                                                                array., 0, 1, 'YES', SLICE ]
-      - [ def, null, SLICE, arg2, 1, 4, int, 10, 4, 0, 4, 1, returns a slice of an
-                                                               array., 4, 2, 'YES', SLICE ]
-      - [ def, null, SLICE, arg3, 1, 4, int, 10, 4, 0, 4, 1, returns a slice of an
-                                                               array., 4, 3, 'YES', SLICE ]
-      - [ def, null, SLICE, argReturn, 4, 0, null, 0, 0, 0, 0, 1, returns a slice of
-                                                                    an array., 0, 3, 'YES', SLICE ]
-      - [ def, null, SIZE, arg1, 1, 0, array, 0, 0, 0, 0, 1, returns the size of an
-                                                               array., 0, 1, 'YES', SIZE ]
-      - [ def, null, SIZE, argReturn, 4, 2, numeric, 34, 16, 34, 16, 1, returns the
-                                                                          size of an array., 16, 1, 'YES', SIZE ]
-      - [ def, null, SUBSTRING, arg1, 1, -1, string, 0, 0, 0, 0, 1, takes a substring
-                                                                      from a string, 0, 1, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, arg2, 1, 4, long, 19, 8, 0, 8, 1, takes a substring
-                                                                    from a string, 8, 2, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, argReturn, 4, -1, string, 0, 0, 0, 0, 1, takes a substring
-                                                                           from a string, 0, 2, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, arg1, 1, -1, string, 0, 0, 0, 0, 1, takes a substring
-                                                                      from a string, 0, 1, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, arg2, 1, 4, long, 19, 8, 0, 8, 1, takes a substring
-                                                                    from a string, 8, 2, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, arg3, 1, 4, long, 19, 8, 0, 8, 1, takes a substring
-                                                                    from a string, 8, 3, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, argReturn, 4, -1, string, 0, 0, 0, 0, 1, takes a substring
-                                                                           from a string, 0, 3, 'YES', SUBSTRING ]
-      - [ def, null, TRIM, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns the string str
-                                                                 with all remstr prefixes and/or suffixes removed., 0, 1, 'YES', TRIM ]
-      - [ def, null, TRIM, argReturn, 4, -1, string, 0, 0, 0, 0, 1, returns the string
-                                                                      str with all remstr prefixes and/or suffixes removed., 0, 1, 'YES', TRIM ]
-      - [ def, null, TRIM, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns the string str
-                                                                 with all remstr prefixes and/or suffixes removed., 0, 1, 'YES', TRIM ]
-      - [ def, null, TRIM, arg2, 1, -1, string, 0, 0, 0, 0, 1, returns the string str
-                                                                 with all remstr prefixes and/or suffixes removed., 0, 2, 'YES', TRIM ]
-      - [ def, null, TRIM, argReturn, 4, -1, string, 0, 0, 0, 0, 1, returns the string
-                                                                      str with all remstr prefixes and/or suffixes removed., 0, 2, 'YES', TRIM ]
-      - [ def, null, TRIM, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns the string str
-                                                                 with all remstr prefixes and/or suffixes removed., 0, 1, 'YES', TRIM ]
-      - [ def, null, TRIM, arg2, 1, -1, string, 0, 0, 0, 0, 1, returns the string str
-                                                                 with all remstr prefixes and/or suffixes removed., 0, 2, 'YES', TRIM ]
-      - [ def, null, TRIM, arg3, 1, -1, string, 0, 0, 0, 0, 1, returns the string str
-                                                                 with all remstr prefixes and/or suffixes removed., 0, 3, 'YES', TRIM ]
-      - [ def, null, TRIM, argReturn, 4, -1, string, 0, 0, 0, 0, 1, returns the string
-                                                                      str with all remstr prefixes and/or suffixes removed., 0, 3, 'YES', TRIM ]
-      - [ def, null, UPPER, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns the provided
-                                                                  string with all characters changed to uppercase., 0, 1, 'YES', UPPER ]
-      - [ def, null, UPPER, argReturn, 4, -1, string, 0, 0, 0, 0, 1, returns the provided
-                                                                       string with all characters changed to uppercase., 0, 1, 'YES', UPPER ]
-    row_count: 52
-
+      - [def, null, BIT_LENGTH, arg1, 1, -1, string, null, 0, null, 0, 1, returns
+          length of string in bits, null, 1, 'YES', BIT_LENGTH]
+      - [def, null, BIT_LENGTH, argReturn, 4, -5, long, 19, 8, null, 2, 1, returns
+          length of string in bits, null, 1, 'YES', BIT_LENGTH]
+      - [def, null, CHAR_LENGTH, arg1, 1, -1, string, null, 0, null, 0, 1, returns
+          length of string, null, 1, 'YES', CHAR_LENGTH]
+      - [def, null, CHAR_LENGTH, argReturn, 4, -5, long, 19, 8, null, 2, 1, returns
+          length of string, null, 1, 'YES', CHAR_LENGTH]
+      - [def, null, CURRENT_TIMESTAMP, argReturn, 4, 93, date, 24, 8, 3, 0, 1, returns
+          the current date and time., null, 0, 'YES', CURRENT_TIMESTAMP]
+      - [def, null, CURRENT_TIMESTAMP, arg1, 1, 4, int, 10, 4, null, 2, 1, returns
+          the current date and time., null, 1, 'YES', CURRENT_TIMESTAMP]
+      - [def, null, CURRENT_TIMESTAMP, argReturn, 4, 93, date, 24, 8, 3, 0, 1, returns
+          the current date and time., null, 1, 'YES', CURRENT_TIMESTAMP]
+      - [def, null, EXTRACT, arg1, 1, -1, string, null, 0, null, 0, 1, returns the
+          value of the specified unit from the provided date., null, 1, 'YES', EXTRACT]
+      - [def, null, EXTRACT, arg2, 1, 93, date, 24, 8, 3, 0, 1, returns the value
+          of the specified unit from the provided date., null, 2, 'YES', EXTRACT]
+      - [def, null, EXTRACT, argReturn, 4, -5, long, 19, 8, null, 2, 1, returns the
+          value of the specified unit from the provided date., null, 2, 'YES', EXTRACT]
+      - [def, null, LOWER, arg1, 1, -1, string, null, 0, null, 0, 1, returns the provided
+          string with all characters changed to lowercase., null, 1, 'YES', LOWER]
+      - [def, null, LOWER, argReturn, 4, -1, string, null, 0, null, 0, 1, returns
+          the provided string with all characters changed to lowercase., null, 1,
+        'YES', LOWER]
+      - [def, null, OCTET_LENGTH, arg1, 1, -1, string, null, 0, null, 0, 1, returns
+          length of string in bytes, null, 1, 'YES', OCTET_LENGTH]
+      - [def, null, OCTET_LENGTH, argReturn, 4, -5, long, 19, 8, null, 2, 1, returns
+          length of string in bytes, null, 1, 'YES', OCTET_LENGTH]
+      - [def, null, POSITION, arg1, 1, -1, string, null, 0, null, 0, 1, returns the
+          position of the first occurrence of substring substr in string str., null,
+        1, 'YES', POSITION]
+      - [def, null, POSITION, arg2, 1, -1, string, null, 0, null, 0, 1, returns the
+          position of the first occurrence of substring substr in string str., null,
+        2, 'YES', POSITION]
+      - [def, null, POSITION, argReturn, 4, -5, long, 19, 8, null, 2, 1, returns the
+          position of the first occurrence of substring substr in string str., null,
+        2, 'YES', POSITION]
+      - [def, null, SIZE, arg1, 1, 1111, array, null, 0, null, 0, 1, returns the size
+          of an array., null, 1, 'YES', SIZE]
+      - [def, null, SIZE, argReturn, 4, 3, decimal, 34, 16, 34, 10, 1, returns the
+          size of an array., null, 1, 'YES', SIZE]
+      - [def, null, SUBSTRING, arg1, 1, -1, string, null, 0, null, 0, 1, takes a substring
+          from a string, null, 1, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, arg2, 1, -5, long, 19, 8, null, 2, 1, takes a substring
+          from a string, null, 2, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, argReturn, 4, -1, string, null, 0, null, 0, 1, takes
+          a substring from a string, null, 2, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, arg1, 1, -1, string, null, 0, null, 0, 1, takes a substring
+          from a string, null, 1, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, arg2, 1, -5, long, 19, 8, null, 2, 1, takes a substring
+          from a string, null, 2, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, arg3, 1, -5, long, 19, 8, null, 2, 1, takes a substring
+          from a string, null, 3, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, argReturn, 4, -1, string, null, 0, null, 0, 1, takes
+          a substring from a string, null, 3, 'YES', SUBSTRING]
+      - [def, null, TRIM, arg1, 1, -1, string, null, 0, null, 0, 1, returns the string
+          str with all remstr prefixes and/or suffixes removed., null, 1, 'YES', TRIM]
+      - [def, null, TRIM, argReturn, 4, -1, string, null, 0, null, 0, 1, returns the
+          string str with all remstr prefixes and/or suffixes removed., null, 1, 'YES',
+        TRIM]
+      - [def, null, TRIM, arg1, 1, -1, string, null, 0, null, 0, 1, returns the string
+          str with all remstr prefixes and/or suffixes removed., null, 1, 'YES', TRIM]
+      - [def, null, TRIM, arg2, 1, -1, string, null, 0, null, 0, 1, returns the string
+          str with all remstr prefixes and/or suffixes removed., null, 2, 'YES', TRIM]
+      - [def, null, TRIM, argReturn, 4, -1, string, null, 0, null, 0, 1, returns the
+          string str with all remstr prefixes and/or suffixes removed., null, 2, 'YES',
+        TRIM]
+      - [def, null, TRIM, arg1, 1, -1, string, null, 0, null, 0, 1, returns the string
+          str with all remstr prefixes and/or suffixes removed., null, 1, 'YES', TRIM]
+      - [def, null, TRIM, arg2, 1, -1, string, null, 0, null, 0, 1, returns the string
+          str with all remstr prefixes and/or suffixes removed., null, 2, 'YES', TRIM]
+      - [def, null, TRIM, arg3, 1, -1, string, null, 0, null, 0, 1, returns the string
+          str with all remstr prefixes and/or suffixes removed., null, 3, 'YES', TRIM]
+      - [def, null, TRIM, argReturn, 4, -1, string, null, 0, null, 0, 1, returns the
+          string str with all remstr prefixes and/or suffixes removed., null, 3, 'YES',
+        TRIM]
+      - [def, null, UPPER, arg1, 1, -1, string, null, 0, null, 0, 1, returns the provided
+          string with all characters changed to uppercase., null, 1, 'YES', UPPER]
+      - [def, null, UPPER, argReturn, 4, -1, string, null, 0, null, 0, 1, returns
+          the provided string with all characters changed to uppercase., null, 1,
+        'YES', UPPER]
+    row_count: 37
   - description: getFunctionColumns partial function and column filters returns matching args
     db: integration_test
-    meta_function: ["getFunctionColumns", "integration_test", null, "%S%", "arg_"]
+    meta_function: [ "getFunctionColumns", "integration_test", null, "%S%", "arg_" ]
     expected_result:
-      - [ def, null, CAST, arg1, 1, 0, null, 0, 0, 0, 0, 1, converts the provided expression
-                                                              into a value of the specified type., 0, 1, 'YES', CAST ]
-      - [ def, null, CAST, arg2, 1, 0, null, 0, 0, 0, 0, 1, converts the provided expression
-                                                              into a value of the specified type., 0, 2, 'YES', CAST ]
-      - [ def, null, CAST, arg3, 1, 0, null, 0, 0, 0, 0, 1, converts the provided expression
-                                                              into a value of the specified type., 0, 3, 'YES', CAST ]
-      - [ def, null, CAST, arg4, 1, 0, null, 0, 0, 0, 0, 1, converts the provided expression
-                                                              into a value of the specified type., 0, 4, 'YES', CAST ]
-      - [ def, null, COALESCE, arg1, 1, 0, null, 0, 0, 0, 0, 1, 'returns the first
-          non-null value in the list, or null if there are no non-null values.', 0,
-          1, 'YES', COALESCE ]
-      - [ def, null, CURRENT_TIMESTAMP, arg1, 1, 0, '', 0, 0, 0, 0, 1, returns the
-                                                                         current date and time., 0, 1, 'YES', CURRENT_TIMESTAMP ]
-      - [ def, null, CURRENT_TIMESTAMP, arg1, 1, 4, int, 10, 4, 0, 4, 1, returns the
-                                                                           current date and time., 4, 1, 'YES', CURRENT_TIMESTAMP ]
-      - [ def, null, POSITION, arg1, 1, -1, string, 0, 0, 0, 0, 1, returns the position
-                                                                     of the first occurrence of substring substr in string str., 0, 1, 'YES',
-          POSITION ]
-      - [ def, null, POSITION, arg2, 1, -1, string, 0, 0, 0, 0, 1, returns the position
-                                                                     of the first occurrence of substring substr in string str., 0, 2, 'YES',
-          POSITION ]
-      - [ def, null, SLICE, arg1, 1, 0, array, 0, 0, 0, 0, 1, returns a slice of an
-                                                                array., 0, 1, 'YES', SLICE ]
-      - [ def, null, SLICE, arg2, 1, 4, int, 10, 4, 0, 4, 1, returns a slice of an
-                                                               array., 4, 2, 'YES', SLICE ]
-      - [ def, null, SLICE, arg3, 1, 4, int, 10, 4, 0, 4, 1, returns a slice of an
-                                                               array., 4, 3, 'YES', SLICE ]
-      - [ def, null, SIZE, arg1, 1, 0, array, 0, 0, 0, 0, 1, returns the size of an
-                                                               array., 0, 1, 'YES', SIZE ]
-      - [ def, null, SUBSTRING, arg1, 1, -1, string, 0, 0, 0, 0, 1, takes a substring
-                                                                      from a string, 0, 1, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, arg2, 1, 4, long, 19, 8, 0, 8, 1, takes a substring
-                                                                    from a string, 8, 2, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, arg1, 1, -1, string, 0, 0, 0, 0, 1, takes a substring
-                                                                      from a string, 0, 1, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, arg2, 1, 4, long, 19, 8, 0, 8, 1, takes a substring
-                                                                    from a string, 8, 2, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, arg3, 1, 4, long, 19, 8, 0, 8, 1, takes a substring
-                                                                    from a string, 8, 3, 'YES', SUBSTRING ]
-    row_count: 18
+      - [def, null, CURRENT_TIMESTAMP, arg1, 1, 4, int, 10, 4, null, 2, 1, returns
+          the current date and time., null, 1, 'YES', CURRENT_TIMESTAMP]
+      - [def, null, POSITION, arg1, 1, -1, string, null, 0, null, 0, 1, returns the
+          position of the first occurrence of substring substr in string str., null,
+        1, 'YES', POSITION]
+      - [def, null, POSITION, arg2, 1, -1, string, null, 0, null, 0, 1, returns the
+          position of the first occurrence of substring substr in string str., null,
+        2, 'YES', POSITION]
+      - [def, null, SIZE, arg1, 1, 1111, array, null, 0, null, 0, 1, returns the size
+          of an array., null, 1, 'YES', SIZE]
+      - [def, null, SUBSTRING, arg1, 1, -1, string, null, 0, null, 0, 1, takes a substring
+          from a string, null, 1, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, arg2, 1, -5, long, 19, 8, null, 2, 1, takes a substring
+          from a string, null, 2, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, arg1, 1, -1, string, null, 0, null, 0, 1, takes a substring
+          from a string, null, 1, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, arg2, 1, -5, long, 19, 8, null, 2, 1, takes a substring
+          from a string, null, 2, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, arg3, 1, -5, long, 19, 8, null, 2, 1, takes a substring
+          from a string, null, 3, 'YES', SUBSTRING]
+    row_count: 9
 
   - description: getFunctionColumns exact function and column filters returns matching args
     db: integration_test
-    meta_function: ["getFunctionColumns", "integration_test", null, "SUBSTRING", "arg1"]
+    meta_function: [ "getFunctionColumns", "integration_test", null, "SUBSTRING", "arg1" ]
     expected_result:
-      - [ def, null, SUBSTRING, arg1, 1, -1, string, 0, 0, 0, 0, 1, takes a substring
-                                                                      from a string, 0, 1, 'YES', SUBSTRING ]
-      - [ def, null, SUBSTRING, arg1, 1, -1, string, 0, 0, 0, 0, 1, takes a substring
-                                                                      from a string, 0, 1, 'YES', SUBSTRING ]
+      - [def, null, SUBSTRING, arg1, 1, -1, string, null, 0, null, 0, 1, takes a substring
+          from a string, null, 1, 'YES', SUBSTRING]
+      - [def, null, SUBSTRING, arg1, 1, -1, string, null, 0, null, 0, 1, takes a substring
+          from a string, null, 1, 'YES', SUBSTRING]
     row_count: 2

--- a/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
@@ -76,12 +76,27 @@ public enum BsonTypeInfo {
     private final BsonType bsonType;
     private final int jdbcType;
     private final boolean caseSensitivity;
+    // Minimum scale for numeric data and date time data.
     private final int minScale;
+    // Maximum scale for numeric data and date time data.
     private final int maxScale;
+    // Radix (typically either 10 or 2) for numeric data.
     private final int numPrecRadix;
+    // The column/data size for the given type.
+    //  - For numeric data, this is the maximum precision.
+    //  - For character data, this is the maximum length in characters.
+    //  - For datetime data types, this is the length in characters of the String representation (assuming the maximum
+    //  allowed precision of the fractional seconds component).
+    //  - For binary data, this is the maximum length in bytes.
+    //  - For ObjectId (row id data type) data, this is the length in bytes.
+    //  - Null is returned for data types where the column size is not applicable.
     private final Integer precision;
+    // The number of fractional digits for numeric and date time data. Null is returned for data types where
+    // DECIMAL_DIGITS is not applicable.
+    // Also known as scale.
     private final Integer decimalDigits;
-    private final Integer charOctetLength;
+    // The length in bytes for fixed length data type.
+    private final Integer fixedBytesLength;
 
     BsonTypeInfo(
             String bsonName,
@@ -93,7 +108,7 @@ public enum BsonTypeInfo {
             int numPrecRadix,
             Integer precision,
             Integer decimalDigits,
-            Integer charOctetLength) {
+            Integer fixedBytesLength) {
         this.bsonName = bsonName;
         this.bsonType = bsonType;
         this.jdbcType = jdbcType;
@@ -103,7 +118,7 @@ public enum BsonTypeInfo {
         this.numPrecRadix = numPrecRadix;
         this.precision = precision;
         this.decimalDigits = decimalDigits;
-        this.charOctetLength = charOctetLength;
+        this.fixedBytesLength = fixedBytesLength;
     }
 
     public String getBsonName() {
@@ -138,12 +153,27 @@ public enum BsonTypeInfo {
         return precision;
     }
 
+    public Integer getFixedBytesLength() {
+        return fixedBytesLength;
+    }
+
     public Integer getDecimalDigits() {
         return decimalDigits;
     }
 
+    /**
+     *  CHAR_OCTET_LENGTH is the maximum length of binary and character based data in bytes.
+     *  For any other datatype the value is null.
+     *  We can use 'precision' combined with the data type for reporting the correct info.
+     */
     public Integer getCharOctetLength() {
-        return charOctetLength;
+        switch (this.bsonType) {
+            case BINARY:
+            case STRING:
+                return this.precision;
+            default:
+                return null;
+        }
     }
 
     /**
@@ -154,6 +184,9 @@ public enum BsonTypeInfo {
      * @return BsonTypeInfo object corresponding to bson type name.
      */
     public static BsonTypeInfo getBsonTypeInfoByName(String typeName) throws SQLException {
+        if (typeName == null) {
+            throw new SQLException("Missing bson type name. Value is Null");
+        }
         if (!BSON_TYPE_NAMES.contains(typeName)) {
             throw new SQLException("Unknown bson type name: \"" + typeName + "\"");
         }

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -1,15 +1,19 @@
 package com.mongodb.jdbc;
 
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_UNDEFINED;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 import org.bson.BsonInt32;
 import org.bson.BsonNull;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 
 public abstract class MongoDatabaseMetaData implements DatabaseMetaData {
@@ -128,6 +132,10 @@ public abstract class MongoDatabaseMetaData implements DatabaseMetaData {
     protected static final String PAGES = "PAGES";
     protected static final String FILTER_CONDITION = "FILTER_CONDITION";
 
+    protected static final String FUNC_DEFAULT_CATALOG = "def";
+
+    private static final String YES = "YES";
+
     public MongoDatabaseMetaData(MongoConnection conn) {
         this.conn = conn;
     }
@@ -147,6 +155,59 @@ public abstract class MongoDatabaseMetaData implements DatabaseMetaData {
     // since this value is used to set limits on literals and field names.
     // This is arbitrary and conservative.
     static final int APPROXIMATE_DOC_SIZE = 16777000;
+
+    /**
+     * Returns information for a given function argument.
+     *
+     * @param func The function name.
+     * @param i The parameter index.
+     * @param argName The parameter name.
+     * @param argType The parameter type.
+     * @param isReturnColumn Is the parameter a return parameter.
+     * @return the information for the given parameter.
+     */
+    protected Map<String, BsonValue> getFunctionParameterValues(
+            MongoFunctions.MongoFunction func,
+            int i,
+            String argName,
+            String argType,
+            boolean isReturnColumn)
+            throws SQLException {
+        Map<String, BsonValue> info =
+                new LinkedHashMap<
+                        String,
+                        BsonValue>(); // Using a LinkedHashMap to conserve the insertion order
+        BsonTypeInfo bsonTypeInfo =
+                argType == null ? BSON_UNDEFINED : BsonTypeInfo.getBsonTypeInfoByName(argType);
+        info.put(FUNCTION_CAT, new BsonString(FUNC_DEFAULT_CATALOG));
+        info.put(FUNCTION_SCHEM, BsonNull.VALUE);
+        info.put(FUNCTION_NAME, new BsonString(func.name));
+
+        info.put(COLUMN_NAME, new BsonString(argName));
+        info.put(COLUMN_TYPE, asBsonIntOrNull(isReturnColumn ? functionReturn : functionColumnIn));
+        info.put(DATA_TYPE, asBsonIntOrNull(bsonTypeInfo.getJdbcType()));
+        info.put(
+                TYPE_NAME,
+                new BsonString(bsonTypeInfo == BSON_UNDEFINED ? "" : bsonTypeInfo.getBsonName()));
+
+        info.put(PRECISION, asBsonIntOrNull(bsonTypeInfo.getPrecision()));
+        // Note : LENGTH is only reported in getFunctionColumns and getProcedureColumns and is not flagged as 'may be null'
+        // so for unknown length we are defaulting to 0.
+        info.put(LENGTH, asBsonIntOrDefault(bsonTypeInfo.getFixedBytesLength(), 0));
+        info.put(SCALE, asBsonIntOrNull(bsonTypeInfo.getDecimalDigits()));
+        info.put(RADIX, new BsonInt32(bsonTypeInfo.getNumPrecRadix()));
+
+        info.put(NULLABLE, new BsonInt32(functionNullable));
+        info.put(REMARKS, new BsonString(func.comment));
+        info.put(CHAR_OCTET_LENGTH, asBsonIntOrNull(bsonTypeInfo.getCharOctetLength()));
+
+        info.put(ORDINAL_POSITION, new BsonInt32(i));
+        info.put(IS_NULLABLE, new BsonString(YES));
+
+        info.put(SPECIFIC_NAME, new BsonString(func.name));
+
+        return info;
+    }
 
     //----------------------------------------------------------------------
     // First, a variety of minor information about the target database.
@@ -768,188 +829,6 @@ public abstract class MongoDatabaseMetaData implements DatabaseMetaData {
         return false;
     }
 
-    public static String[] typeNames =
-            new String[] {
-                "null",
-                "document",
-                "binData",
-                "numeric",
-                "string",
-                // Keep this for now or Tableau cannot figure out the types properly.
-                "varchar",
-                "long",
-                // Keep this for now or Tableau cannot figure out the types properly.
-                "bigint",
-                "tinyint",
-                "int",
-                "datetime",
-                "date",
-                "double",
-                "decimal",
-            };
-
-    public static final HashMap<String, Integer> typeNums = new HashMap<>();
-    public static final HashMap<String, Integer> typePrecs = new HashMap<>();
-    public static final HashMap<String, Integer> typeScales = new HashMap<>();
-    public static final HashMap<String, Integer> typeBytes = new HashMap<>();
-
-    static {
-        for (String name : typeNames) {
-            typeNums.put(name, typeNum(name));
-            typePrecs.put(name, typePrec(name));
-            typeScales.put(name, typeScale(name));
-            typeBytes.put(name, typeBytes(name));
-        }
-    }
-
-    public static int typeNum(String typeName) {
-        if (typeName == null) {
-            return Types.NULL;
-        }
-        switch (typeName) {
-            case "null":
-                return Types.NULL;
-            case "bool":
-                return Types.BIT;
-            case "document":
-                return Types.NULL;
-            case "binData":
-                return Types.BINARY;
-            case "numeric":
-                return Types.NUMERIC;
-            case "string":
-            case "varchar":
-                return Types.LONGVARCHAR;
-            case "long":
-            case "int":
-            case "bigint":
-            case "tinyint":
-                return Types.INTEGER;
-            case "date":
-            case "datetime":
-                return Types.TIMESTAMP;
-            case "double":
-                return Types.DOUBLE;
-            case "decimal":
-                return Types.DECIMAL;
-        }
-        return 0;
-    }
-
-    public static Integer typePrec(String typeName) {
-        if (typeName == null) {
-            return 0;
-        }
-        switch (typeName) {
-            case "numeric":
-                return 34;
-            case "double":
-                return 15;
-            case "long":
-            case "bigint":
-                return 19;
-            case "int":
-                return 10;
-            case "decimal":
-                return 34;
-        }
-        return 0;
-    }
-
-    public static Integer typeScale(String typeName) {
-        if (typeName == null) {
-            return 0;
-        }
-        switch (typeName) {
-            case "numeric":
-                return 34;
-            case "double":
-                return 15;
-            case "decimal":
-                return 34;
-        }
-        return 0;
-    }
-
-    public static Integer typeBytes(String typeName) {
-        if (typeName == null) {
-            return 0;
-        }
-        switch (typeName) {
-            case "numeric":
-                return 16;
-            case "double":
-                return 8;
-            case "long":
-            case "bigint":
-            case "date":
-            case "datatime":
-                return 8;
-            case "int":
-                return 4;
-            case "decimal":
-                return 16;
-            case "tinyint":
-            case "bool":
-                return 1;
-        }
-        return 0;
-    }
-
-    public static Integer typeRadix(String typeName) {
-        if (typeName == null) {
-            return 0;
-        }
-        switch (typeName) {
-            case "numeric":
-                return 10;
-            case "double":
-                return 2;
-            case "long":
-            case "bigint":
-                return 2;
-            case "int":
-                return 2;
-            case "decimal":
-                return 10;
-        }
-        return 0;
-    }
-
-    protected String getTypeCase(String col, HashMap<String, Integer> outs) {
-        StringBuilder ret = new StringBuilder("case ");
-        ret.append(col);
-        ret.append("\n");
-        for (String name : typeNames) {
-            Integer out = outs.get(name);
-            String range = out == null ? "NULL" : out.toString();
-            ret.append("when ");
-            ret.append("'");
-            ret.append(name);
-            ret.append("' then ");
-            ret.append(range);
-            ret.append(" \n");
-        }
-        ret.append("end");
-        return ret.toString();
-    }
-
-    protected String getDataTypeNumCase(String col) {
-        return getTypeCase(col, typeNums);
-    }
-
-    protected String getDataTypePrecCase(String col) {
-        return getTypeCase(col, typePrecs);
-    }
-
-    protected String getDataTypeScaleCase(String col) {
-        return getTypeCase(col, typeScales);
-    }
-
-    protected String getDataTypeBytesCase(String col) {
-        return getTypeCase(col, typeBytes);
-    }
-
     //--------------------------JDBC 2.0-----------------------------
     @Override
     public boolean supportsResultSetType(int type) throws SQLException {
@@ -1117,9 +996,13 @@ public abstract class MongoDatabaseMetaData implements DatabaseMetaData {
         return false;
     }
 
-    protected BsonValue bsonInt32(Integer i) {
+    protected BsonValue asBsonIntOrNull(Integer i) {
+        return asBsonIntOrDefault(i, null);
+    }
+
+    protected BsonValue asBsonIntOrDefault(Integer i, Integer defaultVal) {
         if (i == null) {
-            return new BsonNull();
+            return defaultVal == null ? new BsonNull() : new BsonInt32(defaultVal);
         }
         return new BsonInt32(i);
     }

--- a/src/main/java/com/mongodb/jdbc/MongoJsonSchema.java
+++ b/src/main/java/com/mongodb/jdbc/MongoJsonSchema.java
@@ -275,7 +275,8 @@ public class MongoJsonSchema {
      *                                                           }
      *
      * @param scalarProperties Contains the basic info (name, bsonType and required flag) for each
-     *     key. Each property is converted into a scalar MongoJsonSchema and added to this parent schema.
+     *     key. Each property is converted into a scalar MongoJsonSchema and added to this parent
+     *     schema.
      */
     @SafeVarargs
     public final void addScalarKeys(ScalarProperties... scalarProperties) {

--- a/src/main/java/com/mongodb/jdbc/MongoSQLFunctions.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLFunctions.java
@@ -14,37 +14,27 @@ public class MongoSQLFunctions extends MongoFunctions {
                             new MongoFunction[] {
                                 new MongoFunction(
                                         "BIT_LENGTH",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns length of string in bits",
-                                        new String[] {"string"}),
-                                new MongoFunction(
-                                        "CAST",
-                                        null,
-                                        "converts the provided expression into a value of the specified type.",
-                                        new String[] {null, null, null, null}),
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()}),
                                 new MongoFunction(
                                         "CHAR_LENGTH",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns length of string",
-                                        new String[] {"string"},
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
-                                        COALESCE,
-                                        null,
-                                        "returns the first non-null value in the list, or null if there are no non-null values.",
-                                        new String[] {null}),
-                                new MongoFunction(
                                         CURRENT_TIMESTAMP,
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns the current date and time.",
-                                        new String[] {""},
+                                        new String[] {},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         CURRENT_TIMESTAMP,
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns the current date and time.",
-                                        new String[] {"int"},
-                                        FunctionCategory.TIME_DATE_FUNC),
+                                        // Timestamp precision
+                                        new String[] {BsonTypeInfo.BSON_INT.getBsonName()}),
                                 /**
                                  * Note EXTRACT supports more than YEAR, MONTH, DAY, HOUR, MINUTE,
                                  * SECOND for the unit. It also supports TIMEZONE_HOUR |
@@ -52,73 +42,83 @@ public class MongoSQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         EXTRACT,
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the value of the specified unit from the provided date.",
-                                        new String[] {"string", "date"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_DATE.getBsonName()
+                                        },
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "LOWER",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the provided string with all characters changed to lowercase.",
-                                        new String[] {"string"}),
-                                new MongoFunction(
-                                        NULLIF,
-                                        null,
-                                        "returns null if the two arguments are equal, and the first argument otherwise.",
-                                        new String[] {null, null}),
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()}),
                                 new MongoFunction(
                                         "OCTET_LENGTH",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns length of string in bytes",
-                                        new String[] {"string"},
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "POSITION",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the position of the first occurrence of substring substr in string str.",
-                                        new String[] {"string", "string"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        },
                                         FunctionCategory.STRING_FUNC),
-                                new MongoFunction(
-                                        "SLICE",
-                                        null,
-                                        "returns a slice of an array.",
-                                        new String[] {"array", "int", "int"}),
                                 new MongoFunction(
                                         "SIZE",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the size of an array.",
-                                        new String[] {"array"}),
+                                        new String[] {BsonTypeInfo.BSON_ARRAY.getBsonName()}),
                                 new MongoFunction(
                                         SUBSTRING,
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "takes a substring from a string",
-                                        new String[] {"string", "long"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         SUBSTRING,
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "takes a substring from a string",
-                                        new String[] {"string", "long", "long"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        },
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "TRIM",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the string str with all remstr prefixes and/or suffixes removed.",
-                                        new String[] {"string"}),
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()}),
                                 new MongoFunction(
                                         "TRIM",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the string str with all remstr prefixes and/or suffixes removed.",
-                                        new String[] {"string", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "TRIM",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the string str with all remstr prefixes and/or suffixes removed.",
-                                        new String[] {"string", "string", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "UPPER",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the provided string with all characters changed to uppercase.",
-                                        new String[] {"string"})
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()})
                             });
         }
 

--- a/src/main/java/com/mongodb/jdbc/MySQLFunctions.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLFunctions.java
@@ -17,39 +17,42 @@ public class MySQLFunctions extends MongoFunctions {
                             new MongoFunction[] {
                                 new MongoFunction(
                                         "ABS",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the absolute value of the provided number.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "ACOS",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the arc cosine of the provided number.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "ASCII",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the numeric value of the leftmost character of the provided string. Returns 0 if the empty string is provided, and NULL if NULL is provided.",
-                                        new String[] {"string"},
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "ASIN",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the arc sine of the provided number.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         ATAN,
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the arc tangent of the number provided.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         ATAN,
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the arc tangent of the number(s) provided.",
-                                        new String[] {"numeric, numeric"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName(),
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName()
+                                        },
                                         FunctionCategory.NUM_FUNC),
                                 /**
                                  * Note ATAN2(number) is supported by the driver but not listed as a
@@ -59,15 +62,18 @@ public class MySQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         "ATAN2",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the arc tangent of the number(s) provided.",
-                                        new String[] {"numeric", "numeric"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName(),
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName()
+                                        },
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "CEIL",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the smallest integer not less than the provided number.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 /**
                                  * Note CHAR(code1, code2, ...) is a valid MySQL function
@@ -76,15 +82,15 @@ public class MySQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         "CHAR",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "interprets each argument as an integer and returns a string consisting of the characters given by the code values of those integers. NULL values are skipped.",
-                                        new String[] {"long"},
+                                        new String[] {BsonTypeInfo.BSON_LONG.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "CHARACTER_LENGTH",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns length of string",
-                                        new String[] {"string"},
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         COALESCE,
@@ -93,137 +99,163 @@ public class MySQLFunctions extends MongoFunctions {
                                         new String[] {null}),
                                 new MongoFunction(
                                         "CONCAT",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the string that results from concatenating the arguments.",
-                                        new String[] {"string"},
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "CONCATWS",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the provided strings concatenated and separated by the provided separator.",
-                                        new String[] {"string", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "CONNECTIONID",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the connection id.",
                                         new String[] {}),
                                 new MongoFunction(
                                         "CONV",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "converts a number from one numeric base system to another, and returns the result as a string value.",
-                                        new String[] {"string", "long", "long"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "CONVERT",
                                         null,
                                         "converts the provided expression into a value of the specified type.",
-                                        new String[] {null, "string"}),
+                                        new String[] {
+                                            null, BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "COS",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the cosine of the provided radians argument.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "COT",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the cotangent of x.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "CURRENT_DATE",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns the current date.",
                                         new String[] {},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         CURRENT_TIMESTAMP,
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns the current date and time.",
                                         new String[] {},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         CURRENT_TIMESTAMP,
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns the current date and time.",
-                                        new String[] {"int"}, // Timestamp precision
-                                        FunctionCategory.TIME_DATE_FUNC),
+                                        // Timestamp precision
+                                        new String[] {BsonTypeInfo.BSON_INT.getBsonName()}),
                                 new MongoFunction(
                                         "CURTIME",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns the current time.",
                                         new String[] {},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "DATABASE",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the current database name as a string.",
                                         new String[] {},
                                         FunctionCategory.SYSTEM_FUNC),
                                 new MongoFunction(
                                         "DATE",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "extracts the date part of the provided date or datetime expression.",
-                                        new String[] {"date"}),
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()}),
                                 new MongoFunction(
                                         "DATEADD",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "adds a specified number of datetime units to the provided datetime value.",
-                                        new String[] {"date", "string", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DATE.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "DATEDIFF",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns date1 - date2 expressed as a value in days.",
-                                        new String[] {"date", "date"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DATE.getBsonName(),
+                                            BsonTypeInfo.BSON_DATE.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "DATEFORMAT",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "formats a datetime value according to the provided format string.",
-                                        new String[] {"date", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DATE.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "DATESUB",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "subtracts a specified number of datetime units from the provided datetime value.",
-                                        new String[] {"date", "string", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DATE.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "DAYNAME",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the name of the weekday for the provided date.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "DAYOFMONTH",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the day of the month for the provided date.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "DAYOFWEEK",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the weekday index (Sunday = 1 ... Saturday = 7) for the provided date.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "DAYOFYEAR",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the day of the year for the provided date.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "DEGREES",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "converts the provided radians argument to degrees.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "ELT",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the Nth element of the list of strings.",
-                                        new String[] {"long", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "EXP",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the value of e raised to the provided power.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 /**
                                  * Note EXTRACT supports more than YEAR, MONTH, DAY, HOUR, MINUTE,
@@ -231,31 +263,34 @@ public class MySQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         EXTRACT,
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the value of the specified unit from the provided date.",
-                                        new String[] {"string", "date"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_DATE.getBsonName()
+                                        },
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "FIELD",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the index of the first argument in the list of the remaining arguments.",
                                         new String[] {null}),
                                 new MongoFunction(
                                         "FLOOR",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the largest integer value not greater than the provided argument.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "FROM_DAYS",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns a date, given a day number.",
-                                        new String[] {"long"}),
+                                        new String[] {BsonTypeInfo.BSON_LONG.getBsonName()}),
                                 new MongoFunction(
                                         "FROM_UNIXTIME",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns a representation of the provided unix timestamp, using the provided format string if one is supplied.",
-                                        new String[] {"long"}),
+                                        new String[] {BsonTypeInfo.BSON_LONG.getBsonName()}),
                                 new MongoFunction(
                                         "GREATEST",
                                         null,
@@ -270,9 +305,9 @@ public class MySQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         "HOUR",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the hour for the provided time.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "IF",
@@ -286,30 +321,41 @@ public class MySQLFunctions extends MongoFunctions {
                                         new String[] {null, null}),
                                 new MongoFunction(
                                         "INSERT",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the string str, with the substring beginning at position pos and len characters long replaced by the string newstr.",
-                                        new String[] {"string", "long", "long", "string"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        },
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "INSTR",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the position of the first occurrence of substring substr in string str.",
-                                        new String[] {"string", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "INTERVAL",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns 0 if N < N1, 1 if N < N2, and so on.",
-                                        new String[] {"numeric", "numeric"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName(),
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "LASTDAY",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "takes a date or datetime value and returns the corresponding value for the last day of the month.",
-                                        new String[] {"date"}),
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()}),
                                 new MongoFunction(
                                         "LCASE",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the provided string with all characters changed to lowercase.",
-                                        new String[] {"string"},
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "LEAST",
@@ -318,9 +364,12 @@ public class MySQLFunctions extends MongoFunctions {
                                         new String[] {null, null}),
                                 new MongoFunction(
                                         "LEFT",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the leftmost n characters from the provided string, or NULL if either argument is NULL.",
-                                        new String[] {"string", "long"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        },
                                         FunctionCategory.STRING_FUNC),
                                 /**
                                  * Note This is equivalent to LENGTH(string, OCTETS) in the String
@@ -330,68 +379,82 @@ public class MySQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         "LENGTH",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "return the length of the provided string, measured in bytes.",
-                                        new String[] {"string"}),
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()}),
                                 new MongoFunction(
                                         "LN",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the natural logarithm of the provided argument.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "LOCATE",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the position of the first occurrence of substring substr in string str, starting at index pos if provided",
-                                        new String[] {"string", "string"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        },
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "LOG",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the logarithm of the provided argument with the provided base (default e).",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "LOG10",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the base-10 logarithm of the provided number.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "LOG2",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the base-2 logarithm of the provided number.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "LPAD",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the string str, left-padded with the string padstr to a length of len characters.",
-                                        new String[] {"string", "long", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "LTRIM",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the provided string with leading space characters removed.",
-                                        new String[] {"string"},
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "MAKEDATE",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns a date, given year and day-of-year values. day_of_year must be greater than zero, or the result is NULL.",
-                                        new String[] {"long", "long"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "MD5",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns an MD5 128-bit checksum for the provided string.",
-                                        new String[] {"string"}),
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()}),
                                 new MongoFunction(
                                         "MICROSECOND",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the microseconds from the provided expression.",
-                                        new String[] {"date"}),
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()}),
                                 new MongoFunction(
                                         "MID",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "mid(str, pos, len) is a synonym for substring(str, pos, len).",
-                                        new String[] {"string", "long", "long"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        }),
                                 /**
                                  * Note Even though the function works on DateTime values, MySql
                                  * list the argument as Time
@@ -401,27 +464,30 @@ public class MySQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         "MINUTE",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the minute for the provided time.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "MOD",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the remainder of n divided by m.",
-                                        new String[] {"numeric", "numeric"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName(),
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName()
+                                        },
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "MONTH",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the month for the provided date.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "MONTHNAME",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the full name of the month for the provided date.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         NULLIF,
@@ -430,7 +496,7 @@ public class MySQLFunctions extends MongoFunctions {
                                         new String[] {null, null}),
                                 new MongoFunction(
                                         "PI",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the value of pi.",
                                         new String[] {},
                                         FunctionCategory.NUM_FUNC),
@@ -440,65 +506,85 @@ public class MySQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         "POW",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the value of base raised to the power of exp.",
-                                        new String[] {"numeric", "numeric"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName(),
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "QUARTER",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the quarter of the year for the provided date, from 1 to 4.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "RADIANS",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the provided degrees argument to radians.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "RAND",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns a random floating-point value between zero and one, using an integer seed if provided.",
-                                        new String[] {"long"},
+                                        new String[] {BsonTypeInfo.BSON_LONG.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "REPEAT",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns a string consisting of the provided string repeated n times. If n is less than 1, returns an empty string. Returns NULL if either argument is NULL.",
-                                        new String[] {"string", "long"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        },
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "REPLACE",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the string with all occurrences of the string from_str replaced by the string to_str.",
-                                        new String[] {"string", "string", "string"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        },
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "REVERSE",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the provided string with the order of the characters reversed.",
-                                        new String[] {"string"}),
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()}),
                                 new MongoFunction(
                                         "RIGHT",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the rightmost n characters from the provided string, or NULL if any argument is NULL.",
-                                        new String[] {"string", "long"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "ROUND",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "rounds the argument x to d decimal places (or zero places if not specified).",
-                                        new String[] {"numeric", "long"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        },
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "RPAD",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the string str, right-padded with the string padstr to a length of len characters.",
-                                        new String[] {"string", "long", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "RTRIM",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the provided string with trailing space characters removed.",
-                                        new String[] {"string"},
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 /**
                                  * Note Even though the function works on DateTime values, MySql
@@ -509,89 +595,113 @@ public class MySQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         "SECOND",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the second for the provided time, in the range 0-59.",
-                                        new String[] {"date"}),
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()}),
                                 new MongoFunction(
                                         "SIGN",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the sign of the argument as -1, 0, or 1 depending on whether it is negative, zero, or positive.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "SIN",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the sine of the provided radians argument.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "SLEEP",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "pauses for the number of seconds given by the argument, then returns zero.",
                                         new String[] {"decimal"}),
                                 new MongoFunction(
                                         "SPACE",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns a string consisting of n space characters.",
-                                        new String[] {"long"},
+                                        new String[] {BsonTypeInfo.BSON_LONG.getBsonName()},
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "SQRT",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the square root of the provided (non-negative) argument.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "STRTODATE",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "takes a string and a date format string, and attempts to parse a date from the string according to the provided format string.",
-                                        new String[] {"string", "string"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         SUBSTRING,
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "takes a substring from a string starting at the given position",
-                                        new String[] {"string", "long"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         SUBSTRING,
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "takes a substring from a string starting at the given position and with the given lenght",
-                                        new String[] {"string", "long", "long"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        },
                                         FunctionCategory.STRING_FUNC),
                                 new MongoFunction(
                                         "SUBSTRINGINDEX",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the substring from string str before count occurrences of the delimiter delim. If count is positive, everything to the left of the final delimiter (counting from the left) is returned. If count is negative, everything to the right of the final delimiter (counting from the right) is returned. SUBSTRING_INDEX() performs a case-sensitive match when searching for delim.",
-                                        new String[] {"string", "string", "long"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "TAN",
-                                        "double",
+                                        BsonTypeInfo.BSON_DOUBLE.getBsonName(),
                                         "returns the tangent of the provided radians argument.",
-                                        new String[] {"numeric"},
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()},
                                         FunctionCategory.NUM_FUNC),
                                 new MongoFunction(
                                         "TIMEDIFF",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns expr1 - expr2 expressed as a time value.",
-                                        new String[] {"date", "date"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DATE.getBsonName(),
+                                            BsonTypeInfo.BSON_DATE.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "TIMETOSEC",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the provided time argument, converted to seconds.",
-                                        new String[] {"date"}),
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()}),
                                 new MongoFunction(
                                         "TIMESTAMP",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns the provided argument as a datetime value. With two arguments, adds the provided time expression to the first argument and returns the result as a datetime.",
-                                        new String[] {"date", "date"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DATE.getBsonName(),
+                                            BsonTypeInfo.BSON_DATE.getBsonName()
+                                        }),
                                 /**
                                  * Note The function supports the Open CLI interval names SQL_TSI_XX
                                  * but also the shorter Mysql names omitting the SQL_TSI_ prefix.
                                  */
                                 new MongoFunction(
                                         "TIMESTAMPADD",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "adds the integer expression interval to the date or datetime expression datetime_expr. The unit for interval is given by the unit argument, which should be one of MICROSECOND (microseconds), SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.",
-                                        new String[] {"string", "numeric", "date"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName(),
+                                            BsonTypeInfo.BSON_DATE.getBsonName()
+                                        },
                                         FunctionCategory.TIME_DATE_FUNC),
                                 /**
                                  * Note The function supports the Open CLI interval names SQL_TSI_XX
@@ -599,133 +709,140 @@ public class MySQLFunctions extends MongoFunctions {
                                  */
                                 new MongoFunction(
                                         "TIMESTAMPDIFF",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "subtracts the provided timestamps, returning the difference in the specified unit.",
-                                        new String[] {"string", "date", "date"},
+                                        new String[] {
+                                            BsonTypeInfo.BSON_STRING.getBsonName(),
+                                            BsonTypeInfo.BSON_DATE.getBsonName(),
+                                            BsonTypeInfo.BSON_DATE.getBsonName()
+                                        },
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "TODAYS",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the number of days since year zero for the provided date.",
-                                        new String[] {"date"}),
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()}),
                                 new MongoFunction(
                                         "TOSECONDS",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the number of seconds since year zero for the provided date.",
-                                        new String[] {"date"}),
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()}),
                                 new MongoFunction(
                                         "TRIM",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the string str with all remstr prefixes and/or suffixes removed.",
-                                        new String[] {"string"}),
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()}),
                                 new MongoFunction(
                                         "TRUNCATE",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the number x truncated to d decimal places.",
-                                        new String[] {"numeric", "long"}),
+                                        new String[] {
+                                            BsonTypeInfo.BSON_DECIMAL.getBsonName(),
+                                            BsonTypeInfo.BSON_LONG.getBsonName()
+                                        }),
                                 new MongoFunction(
                                         "UCASE",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the provided string with all characters changed to uppercase.",
-                                        new String[] {"string"}),
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()}),
                                 new MongoFunction(
                                         "UNIX_TIMESTAMP",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the provided timestamp (defaulting to the current timestamp) as seconds since unix epoch.",
                                         new String[] {}),
                                 new MongoFunction(
                                         "USER",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the current MySQL user name and host name as a string.",
                                         new String[] {},
                                         FunctionCategory.SYSTEM_FUNC),
                                 new MongoFunction(
                                         "UTCDATE",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns the current UTC date.",
                                         new String[] {}),
                                 new MongoFunction(
                                         "UTCTIMESTAMP",
-                                        "date",
+                                        BsonTypeInfo.BSON_DATE.getBsonName(),
                                         "returns the current UTC date and time.",
                                         new String[] {}),
                                 new MongoFunction(
                                         "VERSION",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns a string that indicates the MySQL server version.",
                                         new String[] {}),
                                 new MongoFunction(
                                         "WEEK",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the week number for date.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "WEEKDAY",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the weekday index (Monday = 0 ... Sunday = 6) for the provided date.",
-                                        new String[] {"date"}),
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()}),
                                 new MongoFunction(
                                         "YEAR",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the year for the provided date.",
-                                        new String[] {"date"},
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()},
                                         FunctionCategory.TIME_DATE_FUNC),
                                 new MongoFunction(
                                         "YEARWEEK",
-                                        "long",
+                                        BsonTypeInfo.BSON_LONG.getBsonName(),
                                         "returns the year and week for a date.",
-                                        new String[] {"date"}),
+                                        new String[] {BsonTypeInfo.BSON_DATE.getBsonName()}),
                                 new MongoFunction(
                                         "AVG",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the average of elements in a group.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "COUNT",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the count of elements in a group.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "SUM",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the sum of elements in a group.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "MIN",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the minimum element of elements in a group.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "MAX",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns the maximum element of elements in a group.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "GROUP_CONCAT",
-                                        "string",
+                                        BsonTypeInfo.BSON_STRING.getBsonName(),
                                         "returns the concatenation of strings from a group into a single string with various options.",
-                                        new String[] {"string"}),
+                                        new String[] {BsonTypeInfo.BSON_STRING.getBsonName()}),
                                 new MongoFunction(
                                         "STD",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns population standard deviation of a group.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "STDDEV_POP",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns population standard deviation of a group.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "STDDEV",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns population standard deviation of a group.",
-                                        new String[] {"numeric"}),
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()}),
                                 new MongoFunction(
                                         "STDDEV_SAMP",
-                                        "numeric",
+                                        BsonTypeInfo.BSON_DECIMAL.getBsonName(),
                                         "returns cumulative sample standard deviation of a group.",
-                                        new String[] {"numeric"})
+                                        new String[] {BsonTypeInfo.BSON_DECIMAL.getBsonName()})
                             });
         }
 

--- a/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
@@ -406,9 +406,9 @@ class MongoSQLDatabaseMetaDataTest extends MongoDatabaseMetaDataTest {
     @Override
     void testGetFunctions() throws SQLException {
         // All function(s)
-        testGetFunctionsHelper("%", 19);
+        testGetFunctionsHelper("%", 15);
         // All function(s) with a 'S'
-        testGetFunctionsHelper("%S%", 9);
+        testGetFunctionsHelper("%S%", 6);
         // All function(s) with a 's'
         testGetFunctionsHelper("%s%", 0);
         // The 'SUBSTRING' function(s)
@@ -478,7 +478,7 @@ class MongoSQLDatabaseMetaDataTest extends MongoDatabaseMetaDataTest {
 
     @Test
     void testGetTimeDateFunctions() throws SQLException {
-        final String expectedFunctions = "CURRENT_TIMESTAMP," + "CURRENT_TIMESTAMP," + "EXTRACT";
+        final String expectedFunctions = "CURRENT_TIMESTAMP,EXTRACT";
 
         assertEquals(expectedFunctions, databaseMetaData.getTimeDateFunctions());
     }


### PR DESCRIPTION
* Use BsonTypeInfo for functions metadata

* Remove functions with polymorphic arguments or return value from MongoSQLFunctions

Co-authored-by: Natacha Bagnard <>